### PR TITLE
Correct the spelling of EPSILON.

### DIFF
--- a/01.阿里篇/1.1.2 已知sqrt(2)约等于1.414，要求不用数学库，求sqrt(2)精确到小数点后10位.md
+++ b/01.阿里篇/1.1.2 已知sqrt(2)约等于1.414，要求不用数学库，求sqrt(2)精确到小数点后10位.md
@@ -19,22 +19,21 @@ e) 循环到 c)
 a) 前后两次的差值的绝对值<=0.0000000001, 则可退出
 
 ```
-const double EPSINON = 0.0000000001;
+const double EPSILON = 0.0000000001;
 
-double sqrt2( ){
+double sqrt2() {
     double low = 1.4, high = 1.5;
     double mid = (low + high) / 2;
-    
-    while (high - low > EPSINON){
-        if (mid*mid > 2){
+
+    while (high - low > EPSILON) {
+        if (mid * mid > 2) {
             high = mid;
-        }
-        else{
+        } else {
             low = mid;
         }
         mid = (high + low) / 2;
     }
-    
+
     return mid;
 }
 ```


### PR DESCRIPTION
The correct spelling of `ε` which represents precision is  `EPSILON`.
Reformat the code by the way.